### PR TITLE
API-27 - handle corrupt JPEG params better

### DIFF
--- a/content-api-post.js
+++ b/content-api-post.js
@@ -125,6 +125,11 @@ exports.handler = function (event, context, callback) {
       });
     })
     .catch(sharpError => {
+      if (sharpError.contains('VipsJpeg: Invalid SOS parameters for sequential JPEG')) {
+        fail('Processing error: corrupt JPEG, invalid SOS parameters', 400, callback);
+        return;
+      }
+
       fail('Processing error: ' + sharpError, 500, callback);
     })
 };


### PR DESCRIPTION
Looks like this error happens with a certain type of corrupt panorama JPEG file. Should return a 400 bad request (which importantly means we are not notified of it as a crash our side) instead of a 500 internal error.